### PR TITLE
Refresh UI with Material 3–inspired spiritual theme

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,7 +1,5 @@
 import { Tabs } from "expo-router";
 import { HomeIcon, SearchIcon } from "lucide-react-native";
-import { StatusBar } from "expo-status-bar";
-import { SafeAreaView } from "react-native-safe-area-context";
 import { ThemeProvider, useTheme } from "@/context/ThemeContext";
 import ThemedLayout from "@/components/ThemedLayout";
 import Toast from "react-native-toast-message";
@@ -16,47 +14,60 @@ export default function Layout() {
 
 function LayoutContent() {
   const { isDarkMode } = useTheme();
-  const statusBarStyle = isDarkMode ? "light" : "dark";
-  const statusBarBackground = isDarkMode ? "#000" : "#fff7ed";
-  const tabBarStyle = {
-    backgroundColor: isDarkMode ? "#333" : "#fff",
-    height: 60,
-    paddingBottom: 10,
-    paddingTop: 5,
-    borderTopWidth: 0,
-  };
 
   return (
     <>
-    <ThemedLayout>
-      <Tabs
-        screenOptions={{
-          headerShown: false,
-          tabBarHideOnKeyboard: true,
-          tabBarStyle: tabBarStyle,
-        }}
-      >
-        <Tabs.Screen
-          name="home"
-          options={{
-            title: "Home",
-            tabBarIcon: ({ color, size }) => (
-              <HomeIcon color={color} size={size} />
-            ),
+      <ThemedLayout>
+        <Tabs
+          screenOptions={{
+            headerShown: false,
+            tabBarHideOnKeyboard: true,
+            tabBarActiveTintColor: isDarkMode ? "#FFB59D" : "#8A4D24",
+            tabBarInactiveTintColor: isDarkMode ? "#B8B2C1" : "#8A7D74",
+            tabBarLabelStyle: {
+              fontSize: 12,
+              fontWeight: "600",
+              marginBottom: 3,
+            },
+            tabBarStyle: {
+              position: "absolute",
+              marginHorizontal: 16,
+              marginBottom: 14,
+              borderRadius: 28,
+              height: 68,
+              paddingBottom: 8,
+              paddingTop: 8,
+              backgroundColor: isDarkMode ? "#2B2930" : "#FFFDF9",
+              borderTopWidth: 0,
+              elevation: 6,
+              shadowColor: "#000",
+              shadowOpacity: 0.15,
+              shadowOffset: { width: 0, height: 4 },
+              shadowRadius: 12,
+            },
           }}
-        />
-        <Tabs.Screen
-          name="explore"
-          options={{
-            title: "Explore",
-            tabBarIcon: ({ color, size }) => (
-              <SearchIcon color={color} size={size} />
-            ),
-          }}
-        />
-      </Tabs>
-    </ThemedLayout>
-     <Toast />
-     </>
+        >
+          <Tabs.Screen
+            name="home"
+            options={{
+              title: "Home",
+              tabBarIcon: ({ color, size }) => (
+                <HomeIcon color={color} size={size} />
+              ),
+            }}
+          />
+          <Tabs.Screen
+            name="explore"
+            options={{
+              title: "Explore",
+              tabBarIcon: ({ color, size }) => (
+                <SearchIcon color={color} size={size} />
+              ),
+            }}
+          />
+        </Tabs>
+      </ThemedLayout>
+      <Toast />
+    </>
   );
 }

--- a/app/(tabs)/explore/_layout.tsx
+++ b/app/(tabs)/explore/_layout.tsx
@@ -1,14 +1,12 @@
 import { useTheme } from "@/context/ThemeContext";
 import { Stack } from "expo-router";
-import { SafeAreaView } from "react-native-safe-area-context";
-import { StatusBar } from "expo-status-bar";
 import ThemedLayout from "@/components/ThemedLayout";
 
 export default function ExploreLayout() {
   const { isDarkMode } = useTheme();
 
-  const headerBg = isDarkMode ? "#1f2937" : "#fff7ed";
-  const headerText = isDarkMode ? "#facc15" : "#92400e";
+  const headerBg = isDarkMode ? "#2B2930" : "#FFFDF9";
+  const headerText = isDarkMode ? "#FFB59D" : "#8A4D24";
 
   return (
     <ThemedLayout>
@@ -16,7 +14,7 @@ export default function ExploreLayout() {
         screenOptions={{
           headerShown: true,
           headerStyle: { backgroundColor: headerBg },
-          headerTitleStyle: { color: headerText },
+          headerTitleStyle: { color: headerText, fontWeight: "700" },
           headerTintColor: headerText,
           animation: "ios_from_right",
           headerTitleAlign: "center",

--- a/app/(tabs)/explore/about.tsx
+++ b/app/(tabs)/explore/about.tsx
@@ -1,30 +1,40 @@
-import React from 'react';
-import { View, Text, Linking, TouchableOpacity, ScrollView } from 'react-native';
-import { useThemeStyle } from '@/hooks/useThemeStyle'; // Importing the custom hook
-import { useTheme } from '@/context/ThemeContext';
+import React from "react";
+import { Text, Linking, TouchableOpacity, ScrollView } from "react-native";
+import { useTheme } from "@/context/ThemeContext";
+import { LinearGradient } from "expo-linear-gradient";
 
 const About = () => {
-   const { isDarkMode } = useTheme();
-   const bgColor = isDarkMode ? 'bg-gray-900' : 'bg-amber-50';
-   const textColor = isDarkMode ? 'text-white' : 'text-amber-900';
-   const sectionBg = isDarkMode ? 'bg-gray-800' : 'bg-white';
+  const { isDarkMode } = useTheme();
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const subTextColor = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
 
   return (
-    <ScrollView className={`flex-1 ${bgColor} px-6 py-8`}>
-      <Text className={`text-2xl font-bold mb-4 ${textColor}`}>About</Text>
-      <Text className={`text-base leading-relaxed mb-6 ${textColor}`}>
-        I'm Khilan Patel — a full stack developer passionate about building spiritual, minimal, and modern apps. I work with React, Next.js, Nuxt.js, Vue.js, Express, Node.js, Expo, and React Native.
-        {'\n\n'}
-        I built this Bhagavad Gita app to help bring the eternal wisdom of the Gita to more people — completely free and ad-free, for a peaceful experience.
-      </Text>
+    <LinearGradient
+      colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
+      className="flex-1"
+    >
+      <ScrollView className="flex-1 px-6 py-8">
+        <Text className={`text-2xl font-bold mb-4 ${textColor}`}>About</Text>
+        <Text className={`text-base leading-relaxed mb-6 ${subTextColor}`}>
+          I'm Khilan Patel — a full stack developer passionate about building
+          spiritual, minimal, and modern apps. I work with React, Next.js,
+          Nuxt.js, Vue.js, Express, Node.js, Expo, and React Native.
+          {"\n\n"}
+          I built this Bhagavad Gita app to help bring the eternal wisdom of the
+          Gita to more people — completely free and ad-free, for a peaceful
+          experience.
+        </Text>
 
-      <TouchableOpacity
-        className={`rounded-xl px-4 py-3 bg-yellow-500`} // Hardcoding buttonBg as it's a specific color, adjust accordingly
-        onPress={() => Linking.openURL('https://www.buymeacoffee.com/khilanpatel')}
-      >
-        <Text className="text-center text-white font-semibold text-lg">☕ Buy Me a Coffee</Text>
-      </TouchableOpacity>
-    </ScrollView>
+        <TouchableOpacity
+          className="rounded-2xl px-4 py-3 bg-[#8A4D24]"
+          onPress={() => Linking.openURL("https://www.buymeacoffee.com/khilanpatel")}
+        >
+          <Text className="text-center text-white font-semibold text-lg">
+            ☕ Buy Me a Coffee
+          </Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </LinearGradient>
   );
 };
 

--- a/app/(tabs)/explore/contactSupport.tsx
+++ b/app/(tabs)/explore/contactSupport.tsx
@@ -1,26 +1,30 @@
-import React from 'react';
-import { View, Text, TouchableOpacity, Linking } from 'react-native';
-import { useThemeStyle } from '@/hooks/useThemeStyle';
-import { useTheme } from '@/context/ThemeContext';
+import React from "react";
+import { View, Text, TouchableOpacity, Linking } from "react-native";
+import { useTheme } from "@/context/ThemeContext";
+import { LinearGradient } from "expo-linear-gradient";
 
 const ContactSupport = () => {
   const { isDarkMode } = useTheme();
-  const bgColor = isDarkMode ? 'bg-gray-900' : 'bg-amber-50';
-  const textColor = isDarkMode ? 'text-white' : 'text-amber-900';
-  const sectionBg = isDarkMode ? 'bg-gray-800' : 'bg-white';
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const subTextColor = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
 
   return (
-    <View className={`flex-1 ${bgColor} justify-center items-center px-6`}>
-      <Text className={`text-base mb-4 ${textColor}`}>
-        For questions, suggestions, or bug reports, feel free to reach out.
-      </Text>
-      <TouchableOpacity
-        onPress={() => Linking.openURL('mailto:khilanpatel15@gmail.com')}
-        className="bg-yellow-500 px-4 py-3 rounded-xl"
-      >
-        <Text className="text-white font-semibold">Email Support</Text>
-      </TouchableOpacity>
-    </View>
+    <LinearGradient
+      colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
+      className="flex-1"
+    >
+      <View className="flex-1 justify-center items-center px-6">
+        <Text className={`text-base mb-4 text-center ${subTextColor}`}>
+          For questions, suggestions, or bug reports, feel free to reach out.
+        </Text>
+        <TouchableOpacity
+          onPress={() => Linking.openURL("mailto:khilanpatel15@gmail.com")}
+          className="bg-[#8A4D24] px-5 py-3 rounded-2xl"
+        >
+          <Text className="text-white font-semibold">Email Support</Text>
+        </TouchableOpacity>
+      </View>
+    </LinearGradient>
   );
 };
 

--- a/app/(tabs)/explore/index.tsx
+++ b/app/(tabs)/explore/index.tsx
@@ -5,14 +5,15 @@ import { useTheme } from "@/context/ThemeContext";
 import { Alert } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Trash2 } from "lucide-react-native";
+import { LinearGradient } from "expo-linear-gradient";
 
 const Explore = () => {
   const router = useRouter();
-  const { toggleTheme } = useTheme();
-  const { isDarkMode } = useTheme();
-  const bgColor = isDarkMode ? "bg-gray-900" : "bg-amber-50";
-  const textColor = isDarkMode ? "text-white" : "text-amber-900";
-  const sectionBg = isDarkMode ? "bg-gray-800" : "bg-white";
+  const { toggleTheme, isDarkMode } = useTheme();
+
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const subTextColor = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
+  const sectionBg = isDarkMode ? "bg-[#2B2930]" : "bg-[#FFFDF9]";
 
   const options = [
     {
@@ -35,67 +36,81 @@ const Explore = () => {
   ];
 
   return (
-    <ScrollView
-      className={`flex-1 ${bgColor} px-6 py-8`}
-      contentContainerStyle={{ paddingBottom: 40 }}
+    <LinearGradient
+      colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
+      className="flex-1"
     >
-      <Text className={`text-3xl font-bold mb-6 ${textColor}`}>Explore</Text>
-
-      <View
-        className={`p-4 rounded-xl mb-6 ${sectionBg} flex-row justify-between items-center`}
+      <ScrollView
+        className="flex-1 px-6 py-8"
+        contentContainerStyle={{ paddingBottom: 40 }}
       >
-        <Text className={`text-lg font-medium ${textColor}`}>Dark Mode</Text>
-        <Switch
-          value={isDarkMode}
-          onValueChange={toggleTheme}
-          thumbColor={isDarkMode ? "#fbbf24" : "#fcd34d"}
-          trackColor={{ false: "#d1d5db", true: "#78350f" }}
-        />
-      </View>
-
-      {options.map((item, index) => (
-        <TouchableOpacity
-          key={index}
-          className={`p-4 rounded-xl mb-4 ${sectionBg}`}
-          onPress={item.onPress}
-        >
-          <Text className={`text-lg ${textColor}`}>{item.label}</Text>
-        </TouchableOpacity>
-      ))}
-      <TouchableOpacity
-        className={`p-4 rounded-xl mt-6 mb-10 border border-red-400 flex-row items-center justify-center space-x-2`}
-        onPress={() => {
-          Alert.alert(
-            "Clear All Data",
-            "Are you sure you want to clear your data? This will erase all your favourite verses and reading progress.",
-            [
-              { text: "Cancel", style: "cancel" },
-              {
-                text: "Yes, Clear All",
-                style: "destructive",
-                onPress: async () => {
-                  try {
-                    await AsyncStorage.clear();
-                    Alert.alert("Success", "All your data has been cleared.");
-                  } catch (error) {
-                    Alert.alert(
-                      "Error",
-                      "Something went wrong while clearing data."
-                    );
-                    console.error("Clear AsyncStorage error:", error);
-                  }
-                },
-              },
-            ]
-          );
-        }}
-      >
-        <Trash2 size={20} color="#ef4444" />
-        <Text className="text-red-400 font-medium text-lg ms-2">
-          Clear All Data
+        <Text className={`text-3xl font-bold mb-2 ${textColor}`}>Explore</Text>
+        <Text className={`text-sm mb-6 ${subTextColor}`}>
+          Manage preferences and learn more about the app.
         </Text>
-      </TouchableOpacity>
-    </ScrollView>
+
+        <View
+          className={`p-4 rounded-2xl mb-6 ${sectionBg} flex-row justify-between items-center border border-[#E8D5C4]`}
+        >
+          <View>
+            <Text className={`text-lg font-semibold ${textColor}`}>Dark Mode</Text>
+            <Text className={`text-xs mt-1 ${subTextColor}`}>
+              Toggle light and dark appearance
+            </Text>
+          </View>
+          <Switch
+            value={isDarkMode}
+            onValueChange={toggleTheme}
+            thumbColor={isDarkMode ? "#FFB59D" : "#8A4D24"}
+            trackColor={{ false: "#E8D5C4", true: "#4A4458" }}
+          />
+        </View>
+
+        {options.map((item, index) => (
+          <TouchableOpacity
+            key={index}
+            className={`p-4 rounded-2xl mb-4 ${sectionBg} border border-[#E8D5C4]`}
+            onPress={item.onPress}
+          >
+            <Text className={`text-lg font-medium ${textColor}`}>{item.label}</Text>
+          </TouchableOpacity>
+        ))}
+
+        <TouchableOpacity
+          className="p-4 rounded-2xl mt-6 mb-10 border border-[#FCA5A5] flex-row items-center justify-center"
+          onPress={() => {
+            Alert.alert(
+              "Clear All Data",
+              "Are you sure you want to clear your data? This will erase all your favourite verses and reading progress.",
+              [
+                { text: "Cancel", style: "cancel" },
+                {
+                  text: "Yes, Clear All",
+                  style: "destructive",
+                  onPress: async () => {
+                    try {
+                      await AsyncStorage.clear();
+                      Alert.alert("Success", "All your data has been cleared.");
+                    } catch (error) {
+                      Alert.alert(
+                        "Error",
+                        "Something went wrong while clearing data."
+                      );
+                      console.error("Clear AsyncStorage error:", error);
+                    }
+                  },
+                },
+              ]
+            );
+          }}
+        >
+          <Trash2 size={20} color="#EF4444" />
+          <Text className="text-red-500 font-semibold text-lg ms-2">
+            Clear All Data
+          </Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </LinearGradient>
   );
 };
 

--- a/app/(tabs)/explore/privacyPolicy.tsx
+++ b/app/(tabs)/explore/privacyPolicy.tsx
@@ -1,25 +1,33 @@
-import React from 'react';
-import { View, Text, ScrollView } from 'react-native';
-import { useThemeStyle } from '@/hooks/useThemeStyle';
-import { useTheme } from '@/context/ThemeContext';
+import React from "react";
+import { Text, ScrollView } from "react-native";
+import { useTheme } from "@/context/ThemeContext";
+import { LinearGradient } from "expo-linear-gradient";
 
 const PrivacyPolicy = () => {
-  const { isDarkMode } = useTheme(); 
-  const bgColor = isDarkMode ? 'bg-gray-900' : 'bg-amber-50';
-  const textColor = isDarkMode ? 'text-white' : 'text-amber-900';
-  const sectionBg = isDarkMode ? 'bg-gray-800' : 'bg-white';
+  const { isDarkMode } = useTheme();
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const subTextColor = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
 
   return (
-    <ScrollView className={`flex-1 ${bgColor} px-6 py-8`}>
-      <Text className={`text-2xl font-bold mb-4 ${textColor}`}>Privacy Policy</Text>
-      <Text className={`text-base leading-relaxed ${textColor}`}>
-        This Bhagavad Gita app does not collect, store, or share any personal user data. We believe in a distraction-free, respectful spiritual experience. No ads, no tracking, no intrusive permissions.
-        {'\n\n'}
-        Your usage of this app is entirely private. We do not collect analytics or log your data. All features work fully offline (except external links, if any).
-        {'\n\n'}
-        Your privacy is sacred — just like the message of the Gita.
-      </Text>
-    </ScrollView>
+    <LinearGradient
+      colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
+      className="flex-1"
+    >
+      <ScrollView className="flex-1 px-6 py-8">
+        <Text className={`text-2xl font-bold mb-4 ${textColor}`}>Privacy Policy</Text>
+        <Text className={`text-base leading-relaxed ${subTextColor}`}>
+          This Bhagavad Gita app does not collect, store, or share any personal
+          user data. We believe in a distraction-free, respectful spiritual
+          experience. No ads, no tracking, no intrusive permissions.
+          {"\n\n"}
+          Your usage of this app is entirely private. We do not collect analytics
+          or log your data. All features work fully offline (except external
+          links, if any).
+          {"\n\n"}
+          Your privacy is sacred — just like the message of the Gita.
+        </Text>
+      </ScrollView>
+    </LinearGradient>
   );
 };
 

--- a/app/(tabs)/explore/rateApp.tsx
+++ b/app/(tabs)/explore/rateApp.tsx
@@ -1,24 +1,35 @@
-import React from 'react';
-import { View, Text, TouchableOpacity, Linking } from 'react-native';
-import { useThemeStyle } from '@/hooks/useThemeStyle';
-import { useTheme } from '@/context/ThemeContext';
+import React from "react";
+import { View, Text, TouchableOpacity, Linking } from "react-native";
+import { useTheme } from "@/context/ThemeContext";
+import { LinearGradient } from "expo-linear-gradient";
 
 const RateApp = () => {
-  const { isDarkMode } = useTheme(); 
-  const bgColor = isDarkMode ? 'bg-gray-900' : 'bg-amber-50';
-  const textColor = isDarkMode ? 'text-white' : 'text-amber-900';
-  const sectionBg = isDarkMode ? 'bg-gray-800' : 'bg-white';
+  const { isDarkMode } = useTheme();
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const subTextColor = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
 
   return (
-    <View className={`flex-1 ${bgColor} justify-center items-center px-6`}>
-      <Text className={`text-xl font-semibold mb-4 ${textColor}`}>Enjoying the app?</Text>
-      <TouchableOpacity
-        onPress={() => Linking.openURL('https://play.google.com/store/apps/details?id=your.app.id')}
-        className="bg-yellow-500 px-4 py-3 rounded-xl"
-      >
-        <Text className="text-white font-semibold">Rate on Play Store</Text>
-      </TouchableOpacity>
-    </View>
+    <LinearGradient
+      colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
+      className="flex-1"
+    >
+      <View className="flex-1 justify-center items-center px-6">
+        <Text className={`text-xl font-semibold mb-2 ${textColor}`}>
+          Enjoying the app?
+        </Text>
+        <Text className={`text-sm mb-4 text-center ${subTextColor}`}>
+          Your rating helps more seekers discover the Gita.
+        </Text>
+        <TouchableOpacity
+          onPress={() =>
+            Linking.openURL("https://play.google.com/store/apps/details?id=your.app.id")
+          }
+          className="bg-[#8A4D24] px-5 py-3 rounded-2xl"
+        >
+          <Text className="text-white font-semibold">Rate on Play Store</Text>
+        </TouchableOpacity>
+      </View>
+    </LinearGradient>
   );
 };
 

--- a/app/(tabs)/explore/termsCondition.tsx
+++ b/app/(tabs)/explore/termsCondition.tsx
@@ -1,25 +1,37 @@
-import React from 'react';
-import { View, Text, ScrollView } from 'react-native';
-import { useThemeStyle } from '@/hooks/useThemeStyle'; // Import the custom hook
-import { useTheme } from '@/context/ThemeContext';
+import React from "react";
+import { Text, ScrollView } from "react-native";
+import { useTheme } from "@/context/ThemeContext";
+import { LinearGradient } from "expo-linear-gradient";
 
 const TermsAndConditions = () => {
-  const { isDarkMode } = useTheme(); 
-  const bgColor = isDarkMode ? 'bg-gray-900' : 'bg-amber-50';
-  const textColor = isDarkMode ? 'text-white' : 'text-amber-900';
-  const sectionBg = isDarkMode ? 'bg-gray-800' : 'bg-white';
+  const { isDarkMode } = useTheme();
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const subTextColor = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
 
   return (
-    <ScrollView className={`flex-1 ${bgColor} px-6 py-8`}>
-      <Text className={`text-2xl font-bold mb-4 ${textColor}`}>Terms & Conditions</Text>
-      <Text className={`text-base leading-relaxed ${textColor}`}>
-        This Bhagavad Gita app is provided as an educational and spiritual resource. All content is sourced from public domain translations and presented with the intention of promoting inner peace and understanding of Hindu philosophy.
-        {'\n\n'}
-        Users are expected to use this app respectfully. No part of this app may be used for commercial purposes without permission. This app is ad-free and does not collect personal data.
-        {'\n\n'}
-        By using this app, you agree to engage with the content in a peaceful, respectful manner.
-      </Text>
-    </ScrollView>
+    <LinearGradient
+      colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
+      className="flex-1"
+    >
+      <ScrollView className="flex-1 px-6 py-8">
+        <Text className={`text-2xl font-bold mb-4 ${textColor}`}>
+          Terms & Conditions
+        </Text>
+        <Text className={`text-base leading-relaxed ${subTextColor}`}>
+          This Bhagavad Gita app is provided as an educational and spiritual
+          resource. All content is sourced from public domain translations and
+          presented with the intention of promoting inner peace and
+          understanding of Hindu philosophy.
+          {"\n\n"}
+          Users are expected to use this app respectfully. No part of this app
+          may be used for commercial purposes without permission. This app is
+          ad-free and does not collect personal data.
+          {"\n\n"}
+          By using this app, you agree to engage with the content in a peaceful,
+          respectful manner.
+        </Text>
+      </ScrollView>
+    </LinearGradient>
   );
 };
 

--- a/app/(tabs)/home/_layout.tsx
+++ b/app/(tabs)/home/_layout.tsx
@@ -1,22 +1,19 @@
 import { useTheme } from "@/context/ThemeContext";
 import { Stack } from "expo-router";
-import { SafeAreaView } from "react-native-safe-area-context";
-import { StatusBar } from "expo-status-bar";
 import ThemedLayout from "@/components/ThemedLayout";
 
 export default function HomeLayout() {
   const { isDarkMode } = useTheme();
 
-  const headerBg = isDarkMode ? "#1f2937" : "#fff7ed";
-  const headerText = isDarkMode ? "#facc15" : "#92400e";
-  const bgColor = isDarkMode ? "#000" : "#fff7ed";
+  const headerBg = isDarkMode ? "#2B2930" : "#FFFDF9";
+  const headerText = isDarkMode ? "#FFB59D" : "#8A4D24";
 
   return (
     <ThemedLayout>
       <Stack
         screenOptions={{
           headerStyle: { backgroundColor: headerBg },
-          headerTitleStyle: { color: headerText },
+          headerTitleStyle: { color: headerText, fontWeight: "700" },
           headerTintColor: headerText,
           animation: "ios_from_right",
           headerTitleAlign: "center",

--- a/app/(tabs)/home/chapters/[id]/[verse_id].tsx
+++ b/app/(tabs)/home/chapters/[id]/[verse_id].tsx
@@ -1,7 +1,6 @@
 import {
   View,
   Text,
-  ActivityIndicator,
   ScrollView,
   TouchableOpacity,
   Switch,
@@ -17,6 +16,7 @@ import {
 } from "lucide-react-native";
 import api from "@/utils/api";
 import { useTheme } from "@/context/ThemeContext";
+import MaterialLoader from "@/components/MaterialLoader";
 import { ProgressBar } from "react-native-paper";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
@@ -94,7 +94,7 @@ export default function VerseDetails() {
   if (loading) {
     return (
       <View className={`flex-1 justify-center items-center ${bgColor}`}>
-        <ActivityIndicator size="large" color="#f59e0b" />
+        <MaterialLoader size="large" />
         <Text className={`mt-2 ${textColor}`}>Loading verse...</Text>
       </View>
     );

--- a/app/(tabs)/home/chapters/[id]/shlokas.tsx
+++ b/app/(tabs)/home/chapters/[id]/shlokas.tsx
@@ -3,13 +3,13 @@ import {
   View,
   Text,
   TouchableOpacity,
-  ActivityIndicator,
 } from "react-native";
 import { useCallback, useState } from "react";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { LinearGradient } from "expo-linear-gradient";
 import api from "@/utils/api";
 import { useTheme } from "@/context/ThemeContext";
+import MaterialLoader from "@/components/MaterialLoader";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { CheckCircle } from "lucide-react-native";
 
@@ -64,7 +64,7 @@ export default function ShlokasScreen() {
   if (loading || !chapter) {
     return (
       <View className={`flex-1 justify-center items-center ${isDarkMode ? "bg-[#1C1B1F]" : "bg-[#FFF8F1]"}`}>
-        <ActivityIndicator size="large" color="#8A4D24" />
+        <MaterialLoader size="large" />
         <Text className={`mt-2 ${textColor}`}>Loading chapter...</Text>
       </View>
     );

--- a/app/(tabs)/home/chapters/[id]/shlokas.tsx
+++ b/app/(tabs)/home/chapters/[id]/shlokas.tsx
@@ -5,7 +5,7 @@ import {
   TouchableOpacity,
   ActivityIndicator,
 } from "react-native";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { LinearGradient } from "expo-linear-gradient";
 import api from "@/utils/api";
@@ -21,11 +21,10 @@ export default function ShlokasScreen() {
   const router = useRouter();
   const { isDarkMode } = useTheme();
 
-  const bgColor = isDarkMode ? "bg-gray-900" : "bg-amber-50";
-  const textColor = isDarkMode ? "text-white" : "text-amber-900";
-  const sectionBg = isDarkMode ? "bg-gray-800" : "bg-white";
-  const secondaryText = isDarkMode ? "text-gray-400" : "text-gray-600";
-  const [readVerses, setReadVerses] = useState<Set<number>>(new Set());
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const sectionBg = isDarkMode ? "bg-[#2B2930]" : "bg-[#FFFDF9]";
+  const secondaryText = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
+  const borderColor = isDarkMode ? "#4A4458" : "#E8D5C4";
 
   const fetchChapterData = async () => {
     try {
@@ -54,6 +53,8 @@ export default function ShlokasScreen() {
     }
   };
 
+  const [readVerses, setReadVerses] = useState<Set<number>>(new Set());
+
   useFocusEffect(
     useCallback(() => {
       fetchChapterData();
@@ -62,8 +63,8 @@ export default function ShlokasScreen() {
 
   if (loading || !chapter) {
     return (
-      <View className={`flex-1 justify-center items-center ${bgColor}`}>
-        <ActivityIndicator size="large" color="#f59e0b" />
+      <View className={`flex-1 justify-center items-center ${isDarkMode ? "bg-[#1C1B1F]" : "bg-[#FFF8F1]"}`}>
+        <ActivityIndicator size="large" color="#8A4D24" />
         <Text className={`mt-2 ${textColor}`}>Loading chapter...</Text>
       </View>
     );
@@ -71,21 +72,15 @@ export default function ShlokasScreen() {
 
   return (
     <LinearGradient
-      colors={isDarkMode ? ["#111827", "#1f2937"] : ["#fff7ed", "#fefce8"]}
+      colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
       className="flex-1"
     >
-      <ScrollView
-        className={`px-6 pt-6 ${bgColor}`}
-        contentContainerStyle={{ paddingBottom: 25 }}
-      >
+      <ScrollView className="px-6 pt-6" contentContainerStyle={{ paddingBottom: 90 }}>
         <View
-          className={`mb-8 p-6 rounded-3xl ${sectionBg} shadow-md`}
+          className={`mb-8 p-6 rounded-3xl ${sectionBg}`}
           style={{
-            shadowColor: isDarkMode ? "#000" : "#fbbf24",
-            shadowOpacity: 0.1,
-            shadowOffset: { width: 0, height: 3 },
-            shadowRadius: 10,
-            elevation: 4,
+            borderWidth: 1,
+            borderColor,
           }}
         >
           <Text className={`text-3xl font-bold mb-2 ${textColor}`}>
@@ -94,12 +89,11 @@ export default function ShlokasScreen() {
           <Text className={`italic mb-4 text-[15px] ${secondaryText}`}>
             “{chapter.meaning.en}”
           </Text>
-          <Text className={`leading-relaxed text-[16px] ${textColor}`}>
+          <Text className={`leading-relaxed text-[16px] ${secondaryText}`}>
             {chapter.summary.en}
           </Text>
         </View>
 
-        {/* Verse List */}
         {verses.map((verse) => (
           <TouchableOpacity
             key={verse.verse_number}
@@ -108,26 +102,20 @@ export default function ShlokasScreen() {
                 `/home/chapters/${id}/${verse.verse_number}?verses_count=${chapter.verses_count}`
               )
             }
-            className={`rounded-2xl p-5 mb-4 shadow ${sectionBg}`}
-            style={{
-              shadowColor: isDarkMode ? "#000" : "#fbbf24",
-              shadowOpacity: 0.05,
-              shadowOffset: { width: 0, height: 2 },
-              shadowRadius: 8,
-              elevation: 2,
-            }}
+            className={`rounded-3xl p-5 mb-4 ${sectionBg}`}
+            style={{ borderWidth: 1, borderColor }}
           >
             <View className="flex-row justify-between items-center">
-              <View className="border-l-4 border-amber-500 pl-4 flex-1">
-                <Text className={`text-lg font-semibold mb-2 ${textColor}`}>
+              <View className="border-l-4 border-[#D97706] pl-4 flex-1">
+                <Text className={`text-lg font-semibold mb-1 ${textColor}`}>
                   Verse {verse.verse_number}
                 </Text>
-                <Text className={`text-base ${textColor}`}>
+                <Text className={`text-base ${secondaryText}`}>
                   श्लोक {verse.verse_number}
                 </Text>
               </View>
               {readVerses.has(verse.verse_number) && (
-                <CheckCircle size={22} color="#22c55e" className="ml-2" />
+                <CheckCircle size={22} color="#5BB974" className="ml-2" />
               )}
             </View>
           </TouchableOpacity>

--- a/app/(tabs)/home/chapters/index.tsx
+++ b/app/(tabs)/home/chapters/index.tsx
@@ -3,7 +3,6 @@ import {
   TouchableOpacity,
   View,
   Text,
-  ActivityIndicator,
 } from "react-native";
 import { BookOpen } from "lucide-react-native";
 import { useRouter, useFocusEffect } from "expo-router";
@@ -13,6 +12,7 @@ import api from "@/utils/api";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useTheme } from "@/context/ThemeContext";
 import { LinearGradient } from "expo-linear-gradient";
+import MaterialLoader from "@/components/MaterialLoader";
 
 export default function ChaptersScreen() {
   const router = useRouter();
@@ -68,7 +68,7 @@ export default function ChaptersScreen() {
   if (loading) {
     return (
       <View className={`flex-1 justify-center items-center ${isDarkMode ? "bg-[#1C1B1F]" : "bg-[#FFF8F1]"}`}>
-        <ActivityIndicator size="large" color="#8A4D24" />
+        <MaterialLoader size="large" />
         <Text className={`mt-2 ${textColor}`}>Loading chapters...</Text>
       </View>
     );

--- a/app/(tabs)/home/chapters/index.tsx
+++ b/app/(tabs)/home/chapters/index.tsx
@@ -10,19 +10,19 @@ import { useRouter, useFocusEffect } from "expo-router";
 import { ProgressBar } from "react-native-paper";
 import { useCallback, useState } from "react";
 import api from "@/utils/api";
-import { useThemeStyle } from "@/hooks/useThemeStyle";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useTheme } from "@/context/ThemeContext";
+import { LinearGradient } from "expo-linear-gradient";
 
 export default function ChaptersScreen() {
   const router = useRouter();
   const [chapters, setChapters] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const { isDarkMode } = useTheme();
-  const bgColor = isDarkMode ? "bg-gray-900" : "bg-amber-50";
-  const textColor = isDarkMode ? "text-white" : "text-amber-900";
-  const sectionBg = isDarkMode ? "bg-gray-800" : "bg-white";
-  const textMeaningColor = isDarkMode ? "text-gray-400" : "text-gray-700";
+
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const cardBg = isDarkMode ? "bg-[#2B2930]" : "bg-[#FFFDF9]";
+  const textMeaningColor = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
 
   const fetchChapters = async () => {
     try {
@@ -67,60 +67,55 @@ export default function ChaptersScreen() {
 
   if (loading) {
     return (
-      <View className={`flex-1 justify-center items-center ${bgColor}`}>
-        <ActivityIndicator size="large" color="#f59e0b" />
+      <View className={`flex-1 justify-center items-center ${isDarkMode ? "bg-[#1C1B1F]" : "bg-[#FFF8F1]"}`}>
+        <ActivityIndicator size="large" color="#8A4D24" />
         <Text className={`mt-2 ${textColor}`}>Loading chapters...</Text>
       </View>
     );
   }
 
   return (
-    <ScrollView className={`p-2 px-6 ${bgColor}`}
-    contentContainerStyle={{ paddingBottom: 20}}
+    <LinearGradient
+      colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
+      className="flex-1"
     >
-      <Text className={`text-2xl font-bold mb-4 ms-1 ${textColor}`}>
-        📖 All Chapters
-      </Text>
+      <ScrollView className="p-2 px-6" contentContainerStyle={{ paddingBottom: 90 }}>
+        <Text className={`text-3xl font-bold mb-5 mt-3 ${textColor}`}>📖 All Chapters</Text>
 
-      {chapters.map((chapter) => (
-        <TouchableOpacity
-          key={chapter.chapter_number}
-          className={`${sectionBg} rounded-2xl p-4 mb-4 shadow`}
-          onPress={() =>
-            router.push(
-              `/(tabs)/home/chapters/${chapter.chapter_number}/shlokas`
-            )
-          }
-        >
-          <View className="flex-row items-center">
-            <View className="bg-amber-200 p-3 rounded-full mr-4">
-              <BookOpen size={24} color="#92400e" />
+        {chapters.map((chapter) => (
+          <TouchableOpacity
+            key={chapter.chapter_number}
+            className={`${cardBg} rounded-3xl p-4 mb-4 border border-[#E8D5C4]`}
+            onPress={() =>
+              router.push(`/(tabs)/home/chapters/${chapter.chapter_number}/shlokas`)
+            }
+          >
+            <View className="flex-row items-center">
+              <View className="bg-[#FFDDB8] p-3 rounded-full mr-4">
+                <BookOpen size={24} color="#8A4D24" />
+              </View>
+              <View className="flex-1">
+                <Text className={`text-lg font-semibold ${textColor}`}>
+                  Chapter {chapter.chapter_number}: {chapter.name}
+                </Text>
+                <Text className={`text-sm ${textMeaningColor}`}>{chapter.meaning.en}</Text>
+                <Text className={`text-sm ${textMeaningColor}`}>{chapter.meaning.hi}</Text>
+              </View>
             </View>
-            <View className="flex-1">
-              <Text className={`text-lg font-semibold ${textColor}`}>
-                Chapter {chapter.chapter_number}: {chapter.name}
-              </Text>
-              <Text className={`text-sm ${textMeaningColor}`}>
-                {chapter.meaning.en}
-              </Text>
-              <Text className={`text-sm ${textMeaningColor}`}>
-                {chapter.meaning.hi}
-              </Text>
-            </View>
-          </View>
 
-          <View className="mt-4">
-            <ProgressBar
-              progress={chapter.progress}
-              color="#facc15"
-              style={{ height: 8, borderRadius: 4 }}
-            />
-            <Text className="text-sm text-gray-500 mt-1 text-right">
-              {Math.round(chapter.progress * 100)}% Read
-            </Text>
-          </View>
-        </TouchableOpacity>
-      ))}
-    </ScrollView>
+            <View className="mt-4">
+              <ProgressBar
+                progress={chapter.progress}
+                color={isDarkMode ? "#D0BCFF" : "#8A4D24"}
+                style={{ height: 10, borderRadius: 10, backgroundColor: isDarkMode ? "#4A4458" : "#F8E7DA" }}
+              />
+              <Text className={`text-sm mt-1 text-right ${textMeaningColor}`}>
+                {Math.round(chapter.progress * 100)}% Read
+              </Text>
+            </View>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </LinearGradient>
   );
 }

--- a/app/(tabs)/home/favorite/index.tsx
+++ b/app/(tabs)/home/favorite/index.tsx
@@ -1,9 +1,10 @@
-import { View, Text, ScrollView, TouchableOpacity, ActivityIndicator } from "react-native";
+import { View, Text, ScrollView, TouchableOpacity } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useState, useEffect } from "react";
 import { useRouter } from "expo-router";
 import { useTheme } from "@/context/ThemeContext";
 import api from "@/utils/api";
+import MaterialLoader from "@/components/MaterialLoader";
 
 export default function FavoritesScreen() {
   const [favorites, setFavorites] = useState<any[]>([]);
@@ -41,7 +42,7 @@ export default function FavoritesScreen() {
   if (loading) {
     return (
       <View className={`flex-1 justify-center items-center ${bgColor}`}>
-        <ActivityIndicator size="large" color="#f59e0b" />
+        <MaterialLoader size="large" />
         <Text className={`mt-2 ${textColor}`}>Loading favorites...</Text>
       </View>
     );

--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -5,7 +5,6 @@ import {
   Text,
   RefreshControl,
   TouchableOpacity,
-  ActivityIndicator,
 } from "react-native";
 import { useTheme } from "@/context/ThemeContext";
 import {
@@ -27,6 +26,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import ActionSheet, { ActionSheetRef } from "react-native-actions-sheet";
 import { Dimensions } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
+import MaterialLoader from "@/components/MaterialLoader";
 
 export default function HomeScreen() {
   const [shlokaOfTheDay, setShlokaOfTheDay] = useState<any>(null);
@@ -161,7 +161,7 @@ export default function HomeScreen() {
               <Sparkles size={20} color={isDarkMode ? "#D0BCFF" : "#7D5260"} />
             </View>
             {loading ? (
-              <ActivityIndicator size="large" color="#8A4D24" />
+              <MaterialLoader size="large" />
             ) : error ? (
               <Text className={`text-base ${subTextColor} text-center`}>
                 No data available right now. Pull to refresh.

--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   View,
   ScrollView,
@@ -15,17 +15,18 @@ import {
   Star,
   Headphones,
   Sun,
+  Sparkles,
 } from "lucide-react-native";
 import { useRouter } from "expo-router";
 import Toast from "react-native-toast-message";
 import api from "@/utils/api";
 import * as Sharing from "expo-sharing";
-import * as MediaLibrary from "expo-media-library";
 import { captureRef } from "react-native-view-shot";
 import Animated, { FadeInDown } from "react-native-reanimated";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import ActionSheet, { ActionSheetRef } from "react-native-actions-sheet";
 import { Dimensions } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
 
 export default function HomeScreen() {
   const [shlokaOfTheDay, setShlokaOfTheDay] = useState<any>(null);
@@ -34,12 +35,13 @@ export default function HomeScreen() {
   const [error, setError] = useState(false);
   const router = useRouter();
   const { isDarkMode } = useTheme();
-  const bgColor = isDarkMode ? "bg-gray-900" : "bg-amber-50";
-  const textColor = isDarkMode ? "text-white" : "text-amber-900";
-  const sectionBg = isDarkMode ? "bg-gray-800" : "bg-white";
+  const textColor = isDarkMode ? "text-[#E8DEF8]" : "text-[#3E2723]";
+  const subTextColor = isDarkMode ? "text-[#CAC4D0]" : "text-[#625B71]";
+  const cardBg = isDarkMode ? "bg-[#2B2930]" : "bg-[#FFFDF9]";
   const screenHeight = Dimensions.get("window").height;
   const viewRef = useRef<any>(null);
   const actionSheetRef = useRef<ActionSheetRef>(null);
+
   const handlePresentModalPress = () => {
     actionSheetRef.current?.show();
   };
@@ -130,194 +132,133 @@ export default function HomeScreen() {
 
   return (
     <GestureHandlerRootView className="flex-1">
-      <View className={`flex-1 ${bgColor}`}>
+      <LinearGradient
+        colors={isDarkMode ? ["#1C1B1F", "#2B2930"] : ["#FFF8F1", "#FFEAD7"]}
+        className="flex-1"
+      >
         <ScrollView
           refreshControl={
             <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
           }
+          contentContainerStyle={{ paddingBottom: 90 }}
         >
-          {/* Header */}
-          <View className="items-center mt-6 mb-8">
-            <BookText size={80} color="#92400e" />
-            <Text className={`text-4xl font-bold mt-4 ${textColor}`}>
-              Bhagavad Gita
-            </Text>
-            <Text className={`text-base mt-1 ${textColor}`}>
-              Daily Wisdom for the Soul
+          <View className="items-center mt-8 mb-6">
+            <View className="rounded-full p-5 bg-[#FFDDB8]">
+              <BookText size={50} color="#8A4D24" />
+            </View>
+            <Text className={`text-4xl font-bold mt-4 ${textColor}`}>Bhagavad Gita</Text>
+            <Text className={`text-base mt-1 ${subTextColor}`}>
+              Sacred wisdom, beautifully presented
             </Text>
           </View>
 
-          {/* Shloka Card */}
           <View
             ref={viewRef}
-            className={`mx-5 ${sectionBg} rounded-3xl shadow-md p-6 mb-8`}
+            className={`mx-5 ${cardBg} rounded-[28px] p-6 mb-6 border border-[#E8D5C4]`}
           >
-            <Text className={`text-xl font-semibold mb-3 ${textColor}`}>
-              📜 Shloka of the Day
-            </Text>
+            <View className="flex-row items-center justify-between mb-3">
+              <Text className={`text-xl font-semibold ${textColor}`}>🌸 Shloka of the Day</Text>
+              <Sparkles size={20} color={isDarkMode ? "#D0BCFF" : "#7D5260"} />
+            </View>
             {loading ? (
-              <ActivityIndicator size="large" color="#92400e" />
+              <ActivityIndicator size="large" color="#8A4D24" />
             ) : error ? (
-              <Text className={`text-base ${textColor} text-center`}>
-                No data available at the moment. Pull to refresh.
+              <Text className={`text-base ${subTextColor} text-center`}>
+                No data available right now. Pull to refresh.
               </Text>
             ) : shlokaOfTheDay ? (
-              <View className="border-l-4 border-amber-500 pl-4">
-                <Text className={`text-base mb-2 ${textColor}`}>
+              <View className="border-l-4 border-[#D97706] pl-4">
+                <Text className={`text-base mb-2 ${subTextColor}`}>
                   Chapter {shlokaOfTheDay.chapter}, Verse {shlokaOfTheDay.verse}
                 </Text>
-                <Text
-                  className={`text-2xl font-bold leading-relaxed mb-3 ${textColor}`}
-                >
+                <Text className={`text-[22px] font-semibold leading-9 mb-3 ${textColor}`}>
                   {shlokaOfTheDay.text}
                 </Text>
-                <Text className={`text-base leading-relaxed ${textColor}`}>
+                <Text className={`text-base leading-7 ${subTextColor}`}>
                   {shlokaOfTheDay.translation}
                 </Text>
               </View>
             ) : null}
-            <View className="flex-row justify-end mt-4">
-              <TouchableOpacity
-                className="flex-row items-center space-x-1"
-                onPress={shareShloka} // Share the image on button click
-              >
-                <Share2 size={18} color="#92400e" />
-                <Text className="text-amber-700 font-semibold">Share</Text>
+            <View className="flex-row justify-end mt-5">
+              <TouchableOpacity className="flex-row items-center" onPress={shareShloka}>
+                <Share2 size={18} color={isDarkMode ? "#FFB59D" : "#8A4D24"} />
+                <Text className="text-[#8A4D24] font-semibold ml-2">Share</Text>
               </TouchableOpacity>
             </View>
           </View>
 
-          {/* Explore Gita */}
-          <View className={`mx-5 mb-5 rounded-3xl ${sectionBg} p-4`}>
+          <View className={`mx-5 rounded-[28px] ${cardBg} p-4 border border-[#E8D5C4]`}>
             <Text className={`text-xl font-semibold mb-4 ${textColor}`}>
-              🌼 Explore the Gita
+              🙏 Explore Your Spiritual Journey
             </Text>
 
-            <View className="space-y-4">
-              {/* Read Chapters */}
+            {[{
+              icon: <BookOpen size={24} color="#8A4D24" />,
+              title: "Read Chapters",
+              desc: "Explore all 18 chapters with deep meanings",
+              onPress: () => router.push("/(tabs)/home/chapters"),
+              color: "bg-[#FFDDB8]",
+            }, {
+              icon: <Star size={24} color="#8A4D24" />,
+              title: "Favorites",
+              desc: "Keep your most loved verses in one place",
+              onPress: () => router.push("/(tabs)/home/favorite"),
+              color: "bg-[#FFE4C4]",
+            }, {
+              icon: <Headphones size={24} color="#8A4D24" />,
+              title: "Audio Recitations",
+              desc: "Sanskrit chants and guided listening",
+              onPress: handlePresentModalPress,
+              color: "bg-[#FFEAD7]",
+              soon: true,
+            }, {
+              icon: <Sun size={24} color="#8A4D24" />,
+              title: "Daily Practice",
+              desc: "Build a mindful reading routine",
+              onPress: handlePresentModalPress,
+              color: "bg-[#FFEAD7]",
+              soon: true,
+            }].map((item, index) => (
               <Animated.View
-                entering={FadeInDown.duration(1200)}
-                className={`flex-row items-center ${sectionBg} rounded-3xl px-5 py-4`}
+                key={item.title}
+                entering={FadeInDown.duration(1100 + index * 200)}
+                className="mb-3"
               >
-                <View className="bg-amber-200 rounded-full p-3 mr-4 shadow-inner shadow-amber-300">
-                  <BookOpen size={24} color="#92400e" />
-                </View>
                 <TouchableOpacity
-                  onPress={() => router.push("/(tabs)/home/chapters")}
-                  className="flex-1 justify-center"
+                  onPress={item.onPress}
+                  className="rounded-3xl px-4 py-4 flex-row items-center border border-[#EEDBC8]"
                 >
-                  <View>
-                    <Text className={`text-lg font-semibold ${textColor}`}>
-                      Read Chapters
-                    </Text>
-                    <Text className={`text-sm ${textColor} opacity-70`}>
-                      Explore all 18 chapters with meanings
-                    </Text>
+                  <View className={`${item.color} rounded-full p-3 mr-4`}>{item.icon}</View>
+                  <View className="flex-1">
+                    <Text className={`text-lg font-semibold ${textColor}`}>{item.title}</Text>
+                    <Text className={`text-sm mt-1 ${subTextColor}`}>{item.desc}</Text>
                   </View>
+                  {item.soon && (
+                    <View className="bg-[#EADDFF] px-2 py-1 rounded-full">
+                      <Text className="text-xs text-[#4A4458] font-semibold">Coming Soon</Text>
+                    </View>
+                  )}
                 </TouchableOpacity>
               </Animated.View>
-
-              {/* Favorites */}
-              <Animated.View
-                entering={FadeInDown.duration(1800)}
-                className={`flex-row items-center ${sectionBg} rounded-3xl px-5 py-4`}
-              >
-                <View className="bg-yellow-200 rounded-full p-3 mr-4 shadow-inner shadow-yellow-300">
-                  <Star size={24} color="#b45309" />
-                </View>
-                <TouchableOpacity
-                  onPress={() => router.push("/(tabs)/home/favorite")}
-                  className="flex-1 justify-center"
-                >
-                  <Text className={`text-lg font-semibold ${textColor}`}>
-                    Favorites
-                  </Text>
-                  <Text className={`text-sm ${textColor} opacity-70`}>
-                    Bookmark shlokas you love the most
-                  </Text>
-                </TouchableOpacity>
-              </Animated.View>
-
-              {/* Audio Recitations */}
-              <Animated.View
-                entering={FadeInDown.duration(1400)}
-                className={`flex-row items-center ${sectionBg} rounded-3xl px-5 py-4`}
-              >
-                <View className="bg-amber-200 rounded-full p-3 mr-4 shadow-inner shadow-amber-300">
-                  <Headphones size={24} color="#92400e" />
-                </View>
-                <TouchableOpacity
-                  onPress={handlePresentModalPress} // Open the bottom sheet on click
-                  className="flex-1 justify-center"
-                >
-                  <Text className={`text-lg font-semibold ${textColor}`}>
-                    Audio Recitations
-                  </Text>
-                  <Text className={`text-sm ${textColor} opacity-70`}>
-                    Listen to Sanskrit recitations anytime
-                  </Text>
-                </TouchableOpacity>
-                <View className="bg-orange-200 px-2 py-1 rounded-full">
-                  <Text className="text-xs text-orange-900 font-semibold">
-                    Coming Soon
-                  </Text>
-                </View>
-              </Animated.View>
-
-              {/* Daily Practice */}
-              <Animated.View
-                entering={FadeInDown.duration(1600)}
-                className={`flex-row items-center ${sectionBg} rounded-3xl px-5 py-4`}
-              >
-                <View className="bg-orange-200 rounded-full p-3 mr-4 shadow-inner shadow-orange-300">
-                  <Sun size={24} color="#c2410c" />
-                </View>
-                <TouchableOpacity
-                  onPress={handlePresentModalPress}
-                  className="flex-1 justify-center"
-                >
-                  <Text className={`text-lg font-semibold ${textColor}`}>
-                    Daily Practice
-                  </Text>
-                  <Text className={`text-sm ${textColor} opacity-70`}>
-                    Set a daily reminder to read or reflect
-                  </Text>
-                </TouchableOpacity>
-                <View className="bg-orange-200 px-2 py-1 rounded-full ms-1">
-                  <Text className="text-xs text-orange-900 font-semibold">
-                    Coming Soon
-                  </Text>
-                </View>
-              </Animated.View>
-
-              <Animated.View
-                entering={FadeInDown.duration(2000)}
-                className="items-center mt-8"
-              >
-                <Text className={`text-sm ${textColor} opacity-60`}>
-                  Crafted with ❤️ by{" "}
-                  <Text className="text-amber-800 font-semibold">
-                    Khilan Patel
-                  </Text>
-                </Text>
-              </Animated.View>
-            </View>
+            ))}
           </View>
         </ScrollView>
-      </View>
+      </LinearGradient>
       <ActionSheet
         ref={actionSheetRef}
         gestureEnabled={true}
         containerStyle={{
-          backgroundColor: isDarkMode ? "#1f2937" : "#ffffff",
+          backgroundColor: isDarkMode ? "#2B2930" : "#FFFDF9",
           minHeight: screenHeight * 0.15,
+          borderTopLeftRadius: 24,
+          borderTopRightRadius: 24,
         }}
       >
         <Text
           style={{
-            color: isDarkMode ? "#ffffff" : "#1f2937",
+            color: isDarkMode ? "#E8DEF8" : "#3E2723",
           }}
-          className="fs-16 fw-600 text-center p-4 py-10"
+          className="text-center p-8 text-base"
         >
           This feature is still in development. It will be available soon.
         </Text>

--- a/components/MaterialLoader.tsx
+++ b/components/MaterialLoader.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, Easing, View } from "react-native";
+import { useTheme } from "@/context/ThemeContext";
+
+type MaterialLoaderProps = {
+  size?: "small" | "large";
+};
+
+const GOOGLE_COLORS = ["#4285F4", "#EA4335", "#FBBC05", "#34A853"];
+
+export default function MaterialLoader({ size = "large" }: MaterialLoaderProps) {
+  const { isDarkMode } = useTheme();
+  const pulseValues = useRef(GOOGLE_COLORS.map(() => new Animated.Value(0.35))).current;
+
+  useEffect(() => {
+    const animations = pulseValues.map((value, index) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(index * 120),
+          Animated.timing(value, {
+            toValue: 1,
+            duration: 520,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+          Animated.timing(value, {
+            toValue: 0.35,
+            duration: 520,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+        ])
+      )
+    );
+
+    animations.forEach((animation) => animation.start());
+
+    return () => {
+      animations.forEach((animation) => animation.stop());
+    };
+  }, [pulseValues]);
+
+  const dotSize = size === "large" ? 12 : 8;
+
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        paddingVertical: 8,
+      }}
+      accessibilityRole="progressbar"
+      accessibilityLabel="Loading"
+    >
+      {GOOGLE_COLORS.map((color, index) => (
+        <Animated.View
+          key={color}
+          style={{
+            width: dotSize,
+            height: dotSize,
+            borderRadius: dotSize / 2,
+            marginHorizontal: 4,
+            backgroundColor: color,
+            opacity: pulseValues[index],
+            transform: [
+              {
+                scale: pulseValues[index].interpolate({
+                  inputRange: [0.35, 1],
+                  outputRange: [0.9, 1.15],
+                }),
+              },
+            ],
+            shadowColor: isDarkMode ? "#000" : color,
+            shadowOpacity: isDarkMode ? 0.2 : 0.35,
+            shadowRadius: 4,
+            shadowOffset: { width: 0, height: 1 },
+          }}
+        />
+      ))}
+    </View>
+  );
+}

--- a/components/ThemedLayout.tsx
+++ b/components/ThemedLayout.tsx
@@ -9,7 +9,7 @@ interface ThemedLayoutProps {
 
 export default function ThemedLayout({ children }: ThemedLayoutProps) {
   const { isDarkMode } = useTheme();
-  const bgColor = isDarkMode ? "#000" : "#fff7ed";
+  const bgColor = isDarkMode ? "#1C1B1F" : "#FFF8F1";
   const statusStyle = isDarkMode ? "light" : "dark";
 
   return (

--- a/components/ThemedLayout.tsx
+++ b/components/ThemedLayout.tsx
@@ -1,7 +1,8 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
 import { useTheme } from "@/context/ThemeContext";
+import * as SystemUI from "expo-system-ui";
 
 interface ThemedLayoutProps {
   children: ReactNode;
@@ -11,6 +12,10 @@ export default function ThemedLayout({ children }: ThemedLayoutProps) {
   const { isDarkMode } = useTheme();
   const bgColor = isDarkMode ? "#1C1B1F" : "#FFF8F1";
   const statusStyle = isDarkMode ? "light" : "dark";
+
+  useEffect(() => {
+    SystemUI.setBackgroundColorAsync(bgColor).catch(() => undefined);
+  }, [bgColor]);
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: bgColor }}>

--- a/hooks/useThemeStyle.tsx
+++ b/hooks/useThemeStyle.tsx
@@ -3,10 +3,20 @@ import { useTheme } from '@/context/ThemeContext';
 
 export const useThemeStyle = () => {
   const { isDarkMode } = useTheme();
-  const styles = {
-    textColor: isDarkMode ? 'text-white' : 'text-amber-900',
-    bgColor: isDarkMode ? 'bg-gray-900' : 'bg-amber-50',
-    sectionBg: isDarkMode ? 'bg-gray-800' : 'bg-white',
+
+  return {
+    isDarkMode,
+    textColor: isDarkMode ? 'text-[#E8DEF8]' : 'text-[#3E2723]',
+    mutedTextColor: isDarkMode ? 'text-[#CAC4D0]' : 'text-[#625B71]',
+    bgColor: isDarkMode ? 'bg-[#1C1B1F]' : 'bg-[#FFF8F1]',
+    sectionBg: isDarkMode ? 'bg-[#2B2930]' : 'bg-[#FFFDF9]',
+    elevatedBg: isDarkMode ? 'bg-[#352F3F]' : 'bg-[#FFE9D6]',
+    accentBg: isDarkMode ? 'bg-[#4A4458]' : 'bg-[#FFDDB8]',
+    accent: isDarkMode ? '#FFB59D' : '#8A4D24',
+    secondaryAccent: isDarkMode ? '#D0BCFF' : '#7D5260',
+    borderColor: isDarkMode ? '#4A4458' : '#E8D5C4',
+    gradient: isDarkMode
+      ? ['#1C1B1F', '#2B2930', '#3A3444']
+      : ['#FFF8F1', '#FFEDD8', '#FFE5CC'],
   };
-  return styles;
 };


### PR DESCRIPTION
### Motivation

- Give the app a refreshing, more modern visual language inspired by Google Material 3 while keeping a warm, spiritual tone.  
- Improve color, elevation and surface treatment so light and dark modes feel cohesive and calming.  
- Update background and card surfaces to better present the “Shloka of the Day” and chapter navigation.

### Description

- Introduced semantic theme tokens and a Material 3–inspired palette in `hooks/useThemeStyle.tsx` (surface, accents, borders, gradients and text tokens) to centralize colors.  
- Updated the base safe area / status bar background in `components/ThemedLayout.tsx` to match the new light and dark surface colors.  
- Redesigned the bottom tab bar in `app/(tabs)/_layout.tsx` to a floating, rounded container with refined active/inactive tinting and elevated shadow.  
- Reworked the Home screen (`app/(tabs)/home/index.tsx`) and listing screens (`app/(tabs)/home/chapters/index.tsx`, `app/(tabs)/home/chapters/[id]/shlokas.tsx`) to use warm gradients, rounded surface cards, refreshed iconography and typography hierarchy, updated progress bar styling, subtle borders, and a spiritual accent palette; also applied small cleanups (removed an unused import and adjusted loading colors).

### Testing

- Ran TypeScript checks with `npx tsc --noEmit`, which completed successfully.  
- Ran `npm run lint` but it failed in this environment because the Expo CLI attempted a network fetch and errored with `TypeError: fetch failed`.  
- Attempted to start the web build with `npm run web -- --port 8081` for visual verification but Expo startup failed with the same `TypeError: fetch failed` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b8027b188332b8962eabbf906a8a)